### PR TITLE
Update EmployeeEmail.test.js

### DIFF
--- a/Chapter03/src/EmployeeEmail.test.js
+++ b/Chapter03/src/EmployeeEmail.test.js
@@ -8,5 +8,10 @@ test('it accepts a username and displays to the screen', () => {
 
   user.type(input, 'jane doe')
 
-  expect(screen.getByText(/jane.doe@software-plus.com/i)).toBeInTheDocument()
+  // expect(screen.getByText(/jane.doe@software-plus.com/i)).toBeInTheDocument()
+		expect(
+			screen.getByRole('textbox', {
+				name: /enter your name/i,
+			}).value
+		).toEqual('jane doe');
 })


### PR DESCRIPTION
getByText looks by text content. value attribute is not text content but just one of attributes. So it will not find input by this approach.